### PR TITLE
chore(acronymbot): Use whitelisted domain and add proxy

### DIFF
--- a/acronymbot/acronymbot.py
+++ b/acronymbot/acronymbot.py
@@ -9,7 +9,7 @@ log = logging.getLogger(__name__)
 
 slack_token = os.environ["SLACK_API_TOKEN"]
 # override base_url to use whitelisted domain
-rtmclient = slack.RTMClient(token=slack_token, base_url='https://cdis.slack.com/api/')
+rtmclient = slack.RTMClient(token=slack_token, base_url='https://cdis.slack.com/api/', proxy='http://cloud-proxy.internal.io:3128')
 
 @slack.RTMClient.run_on(event='message')
 def find_acronym(**payload):

--- a/acronymbot/acronymbot.py
+++ b/acronymbot/acronymbot.py
@@ -8,7 +8,8 @@ logging.basicConfig(level=logging.INFO)
 log = logging.getLogger(__name__)
 
 slack_token = os.environ["SLACK_API_TOKEN"]
-rtmclient = slack.RTMClient(token=slack_token)
+# override base_url to use whitelisted domain
+rtmclient = slack.RTMClient(token=slack_token, base_url='https://cdis.slack.com/api/')
 
 @slack.RTMClient.run_on(event='message')
 def find_acronym(**payload):


### PR DESCRIPTION
Slack uses Real Time Messaging (web sockets) and I found out our Dev VM can't simply connect to all the required endpoints. So I've set an override against the `base_url` and the `proxy` attributes from the `RTMClient` object.
`base_url='https://cdis.slack.com/api/'`
`proxy='http://cloud-proxy.internal.io:3128')`