### PR TITLE
chore(acronymbot): Removing case sensitivity

### DIFF
--- a/acronymbot/acronymbot.py
+++ b/acronymbot/acronymbot.py
@@ -27,7 +27,7 @@ e.g., @acronym-bot expand CDIS
           """
         else:
           # identify acronym
-          search_term = data['text'].split('expand')[1].strip()
+          search_term = data['text'].split('expand')[1].strip().lower()
           channel_id = data['channel']
           user = data['user']
 
@@ -35,9 +35,10 @@ e.g., @acronym-bot expand CDIS
           link = "https://raw.githubusercontent.com/uc-cdis/acronym-bot/develop/acronyms.txt"
           r = requests.get(link)
           acronyms = json.loads(r.text)
-          if search_term in acronyms.keys():
-            bot_reply = '{} stands for: {}'.format(search_term, acronyms[search_term])
-          else:
+          for k, v in acronyms.items():
+            if search_term == k.lower():
+              bot_reply = '{} stands for: {}'.format(search_term, v)
+          if bot_reply == None:
             bot_reply = 'Sorry :sadpanda: I couldn\'t find {} in the list of acronyms.'.format(search_term)
 
         webclient = payload['web_client']

--- a/acronymbot/acronymbot.py
+++ b/acronymbot/acronymbot.py
@@ -27,7 +27,7 @@ e.g., @acronym-bot expand CDIS
           """
         else:
           # identify acronym
-          search_term = data['text'].split('expand')[1].strip().lower()
+          search_term = data['text'].split('expand')[1].strip()
           channel_id = data['channel']
           user = data['user']
 
@@ -36,7 +36,7 @@ e.g., @acronym-bot expand CDIS
           r = requests.get(link)
           acronyms = json.loads(r.text)
           for k, v in acronyms.items():
-            if search_term == k.lower():
+            if search_term.lower() == k.lower():
               bot_reply = '{} stands for: {}'.format(search_term, v)
           if bot_reply == None:
             bot_reply = 'Sorry :sadpanda: I couldn\'t find {} in the list of acronyms.'.format(search_term)


### PR DESCRIPTION
To avoid false results produced by acronyms with peculiar camel case patterns, e.g., `eRA` != `era` != `ERA`, I am setting both the `search_term` and the dictionary key to *lowercase* before performing the comparison.